### PR TITLE
ci: bump `update_rust_version` to 2.1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Update and commit the release version
         id: release
-        uses: WalletConnect/actions/github/update-rust-version/@2.1.4
+        uses: WalletConnect/actions/github/update-rust-version/@2.1.5
         with:
           token: ${{ secrets.RELEASE_PAT }}
 


### PR DESCRIPTION
# Description

Bumping `update-rust-version` CI action script to 2.1.5 [because of Cargo.lock issue](https://github.com/WalletConnect/actions/issues/20).

Resolves #238 

## How Has This Been Tested?

Test plan in https://github.com/WalletConnect/actions/issues/20

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update